### PR TITLE
feat(artifact): message_id is optional

### DIFF
--- a/src/artifacts/artifacts.service.ts
+++ b/src/artifacts/artifacts.service.ts
@@ -83,13 +83,15 @@ function getSecret() {
 }
 
 export async function createArtifact(body: ArtifactCreateBody): Promise<ArtifactCreateResponse> {
-  const message = await ORM.em.getRepository(Message).findOneOrFail({ id: body.message_id });
+  const message = body.message_id
+    ? await ORM.em.getRepository(Message).findOneOrFail({ id: body.message_id })
+    : undefined;
 
   switch (body.type) {
     case ArtifactType.APP: {
       const artifact = new AppArtifact({
-        thread: ref(message.thread),
-        message: ref(message),
+        thread: message && ref(message.thread),
+        message: message && ref(message),
         sourceCode: body.source_code,
         metadata: body.metadata,
         accessSecret: body.shared === true ? getSecret() : undefined,

--- a/src/artifacts/dtos/artifact-create.ts
+++ b/src/artifacts/dtos/artifact-create.ts
@@ -34,7 +34,7 @@ export const artifactCreateBodySchema = {
   type: 'object',
   oneOf: [
     {
-      required: ['type', 'message_id', 'source_code', 'name'],
+      required: ['type', 'source_code', 'name'],
       additionalProperties: false,
       properties: {
         ...commonArtifactProperties,


### PR DESCRIPTION
We don't have a `message_id` when the user does a copy to edit the artifact.