### PR TITLE
fix(bullmq): update bullmq to fix error reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ajv": "^8.17.1",
     "axios": "^1.7.7",
     "bee-agent-framework": "0.0.54",
-    "bullmq": "^5.32.0",
+    "bullmq": "^5.34.6",
     "bullmq-otel": "^1.0.1",
     "cache-manager": "^5.7.6",
     "dayjs": "^1.11.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: 0.0.54
         version: 0.0.54(@bufbuild/protobuf@1.10.0)(@googleapis/customsearch@3.2.0(encoding@0.1.13))(@grpc/grpc-js@1.12.2)(@grpc/proto-loader@0.7.13)(@ibm-generative-ai/node-sdk@3.2.4(encoding@0.1.13))(@zilliz/milvus2-sdk-node@2.4.4)(encoding@0.1.13)(google-auth-library@9.15.0(encoding@0.1.13))(ollama@0.5.9)(openai-chat-tokens@0.2.8)(openai@4.67.3(encoding@0.1.13)(zod@3.23.8))
       bullmq:
-        specifier: ^5.32.0
-        version: 5.32.0
+        specifier: ^5.34.6
+        version: 5.34.6
       bullmq-otel:
         specifier: ^1.0.1
         version: 1.0.1
@@ -2245,8 +2245,8 @@ packages:
   bullmq-otel@1.0.1:
     resolution: {integrity: sha512-9SSBA/iq8bFUJ9I5bDwv1UmtbJAmIGHt796g5lsYZWasqouTqkFA3+Z/n17mCc8VzfxxygCCCBsXdC1mICbxdw==}
 
-  bullmq@5.32.0:
-    resolution: {integrity: sha512-zNf/DrbCbH+H8fgMshu33OGwrkUZP3c/CyJeFHauglEy5U6Fd9r52ujItRiT1PIODHIG6pCIdWMbpJGCf+Wuxg==}
+  bullmq@5.34.6:
+    resolution: {integrity: sha512-pRCYyO9RlkQWxdmKlrNnUthyFwurYXRYLVXD1YIx+nCCdhAOiHatD8FDHbsT/w2I31c0NWoMcfZiIGuipiF7Lg==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -8001,11 +8001,11 @@ snapshots:
   bullmq-otel@1.0.1:
     dependencies:
       '@opentelemetry/api': 1.9.0
-      bullmq: 5.32.0
+      bullmq: 5.34.6
     transitivePeerDependencies:
       - supports-color
 
-  bullmq@5.32.0:
+  bullmq@5.34.6:
     dependencies:
       cron-parser: 4.9.0
       ioredis: 5.4.1


### PR DESCRIPTION
Should fix this error and report the true error instead:
```
[13:38:51.017] WARN (bee-api): Worker failed {"queueName":"files-extraction-node"}
    err: {
      "type": "TypeError",
      "message": "client[commandNameWithVersion] is not a function",
      "stack":
          TypeError: client[commandNameWithVersion] is not a function
              at Scripts.execCommand (/Users/radek/Code/bee-api/node_modules/.pnpm/bullmq@5.32.0/node_modules/bullmq/src/classes/scripts.ts:74:49)
              at <anonymous> (/Users/radek/Code/bee-api/node_modules/.pnpm/bullmq@5.32.0/node_modules/bullmq/src/classes/job.ts:700:24)
              at <anonymous> (/Users/radek/Code/bee-api/node_modules/.pnpm/bullmq@5.32.0/node_modules/bullmq/src/utils.ts:407:9)
              at NoopContextManager.with (/Users/radek/Code/bee-api/node_modules/.pnpm/@opentelemetry+api@1.9.0/node_modules/@opentelemetry/api/src/context/NoopContextManager.ts:31:15)
              at ContextAPI.with (/Users/radek/Code/bee-api/node_modules/.pnpm/@opentelemetry+api@1.9.0/node_modules/@opentelemetry/api/src/api/context.ts:77:42)
              at BullMQOTelContextManager.with (/Users/radek/Code/bee-api/node_modules/.pnpm/bullmq-otel@1.0.1/node_modules/bullmq-otel/src/bullMQOtel.ts:41:32)
              at trace (/Users/radek/Code/bee-api/node_modules/.pnpm/bullmq@5.32.0/node_modules/bullmq/src/utils.ts:406:39)
              at Worker.trace (/Users/radek/Code/bee-api/node_modules/.pnpm/bullmq@5.32.0/node_modules/bullmq/src/classes/queue-base.ts:201:17)
              at Job.moveToFailed (/Users/radek/Code/bee-api/node_modules/.pnpm/bullmq@5.32.0/node_modules/bullmq/src/classes/job.ts:694:23)
              at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    }
```